### PR TITLE
Update bazel-federation for Bazel 0.26.0

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -1,12 +1,15 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
+# Repositories in this file have been tested with Bazel 0.26.0.
+
 def _maybe(repo, name, **kwargs):
-  if name not in native.existing_rules():
-    repo(name = name, **kwargs)
+    if not native.existing_rule(name):
+        repo(name = name, **kwargs)
 
 def bazel_skylib():
-    _maybe(http_archive, 
+    _maybe(
+        http_archive,
         name = "bazel_skylib",
         url = "https://github.com/bazelbuild/bazel-skylib/archive/0.6.0.tar.gz",
         sha256 = "eb5c57e4c12e68c0c20bc774bfbc60a568e800d025557bc4ea022c6479acc867",
@@ -14,7 +17,7 @@ def bazel_skylib():
     )
 
 def org_golang_x_tools():
-   _maybe(
+    _maybe(
         http_archive,
         name = "org_golang_x_tools",
         # master^1, as of 2018-11-02 (master is currently broken)
@@ -30,7 +33,7 @@ def org_golang_x_tools():
     )
 
 def org_golang_x_sys():
-   _maybe(
+    _maybe(
         git_repository,
         name = "org_golang_x_sys",
         remote = "https://github.com/golang/sys",
@@ -38,8 +41,7 @@ def org_golang_x_sys():
         patches = ["@io_bazel_rules_go//third_party:org_golang_x_sys-gazelle.patch"],
         patch_args = ["-p1"],
         # gazelle args: -go_prefix golang.org/x/sys
-        )
-
+    )
 
 def io_bazel_rules_go():
     org_golang_x_tools()
@@ -66,12 +68,14 @@ def com_github_bazelbuild_buildtools():
     )
 
 def io_bazel_rules_scala():
+    bazel_skylib()
     http_archive(
         name = "io_bazel_rules_scala",
-        strip_prefix = "rules_scala-1354d935a74395b3f0870dd90a04e0376fe22587",
+        strip_prefix = "rules_scala-300b4369a0a56d9e590d9fea8a73c3913d758e12",
         type = "zip",
-        url = "https://github.com/bazelbuild/rules_scala/archive/1354d935a74395b3f0870dd90a04e0376fe22587.zip",
-        sha256 = "5a4b3265ab6b00a0437db958523c3efaf43e8506cce191fec89a19eb08f5b9ec",
+        # commit from 2019-05-27
+        url = "https://github.com/bazelbuild/rules_scala/archive/300b4369a0a56d9e590d9fea8a73c3913d758e12.zip",
+        sha256 = "7f35ee7d96b22f6139b81da3a8ba5fb816e1803ed097f7295b85b7a56e4401c7",
     )
 
 def io_bazel_rules_rust():


### PR DESCRIPTION
Before this commit, the Federation was working with Bazel 0.24, but not 0.25.