### PR TITLE
Add a stardoc example & fix skylib

### DIFF
--- a/examples/skydoc/BUILD
+++ b/examples/skydoc/BUILD
@@ -1,0 +1,33 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@io_bazel_skydoc//stardoc:stardoc.bzl", "stardoc")
+load(":my_rule.bzl", "my_rule")
+
+package(default_visibility = ["//visibility:private"])
+
+bzl_library(
+    name = "my_rule",
+    srcs = [
+        "my_rule.bzl",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+stardoc(
+    name = "my_rule_doc",
+    out = "my_rule_doc.md",
+    input = ":my_rule.bzl",
+    symbol_names = [
+        "my_rule",
+    ],
+    deps = [":my_rule"],
+)
+
+
+my_rule(
+    name = "example",
+    deps = [
+        ":BUILD",
+        ":my_rule.bzl",
+    ],
+    out = "example.txt",
+)

--- a/examples/skydoc/WORKSPACE
+++ b/examples/skydoc/WORKSPACE
@@ -1,0 +1,20 @@
+workspace(name = "example")
+
+local_repository(
+    name = "bazel_federation",
+    path = "../..",
+)
+
+load("@bazel_federation//:repositories.bzl",
+     "bazel_skylib",
+     "bazel_skydoc"
+)
+
+bazel_skylib()
+# TODO(aiuto): This is ugly. Really ugly. See //repositories.bzl for why.
+# What we really need is load from within a macro to be allowed at workspace
+# construction time.
+load("@bazel_federation//repo_deps:bazel_skylib.bzl", "bazel_skylib_deps")
+bazel_skylib_deps()
+
+bazel_skydoc()

--- a/examples/skydoc/my_rule.bzl
+++ b/examples/skydoc/my_rule.bzl
@@ -1,0 +1,24 @@
+
+
+def _my_rule_impl(ctx):
+    """Implementation of my_rule."""
+
+    content = [f.path + '\n' for f in ctx.files.deps]
+    ctx.actions.write(ctx.outputs.out, ''.join(content))
+    return OutputGroupInfo(out=[ctx.outputs.out]);
+
+
+my_rule = rule(
+    implementation = _my_rule_impl,
+    doc = "A simple rule which lists its deps in its output.",
+    attrs = {
+        "deps": attr.label_list(
+            allow_files = True,
+            doc = "A list of rules that are dependencies of this rule.",
+        ),
+        "out": attr.output(
+            mandatory = True,
+            doc = "Output file containing some function of the deps",
+        ),
+    }
+)

--- a/repo_deps/BUILD
+++ b/repo_deps/BUILD
@@ -1,0 +1,1 @@
+exports_files(glob(["*.bzl"]))

--- a/repo_deps/bazel_skylib.bzl
+++ b/repo_deps/bazel_skylib.bzl
@@ -1,0 +1,4 @@
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+def bazel_skylib_deps():
+    bazel_skylib_workspace()

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -16,6 +16,15 @@ def bazel_skylib():
     )
 
 
+def bazel_skydoc():
+    _maybe(
+        http_archive,
+        name = "io_bazel_skydoc",
+        url = "https://github.com/bazelbuild/skydoc/archive/0.3.0.tar.gz",
+        sha256 = "c2d66a0cc7e25d857e480409a8004fdf09072a1bd564d6824441ab2f96448eea",
+   )
+
+
 # The @federation markers are an experiment in how to pick up dependency stanzas
 # from the rule sets. Each rule set should have a deps.bzl file. Inside those,
 # there will be the @federation markers. Those must be designed so they can

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -1,6 +1,9 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
+# TODO(aiuto): This can not exist here, because it loads bazel_skydoc, which is not defined yet
+# TODO(aiuto): load("@bazel_federation//repo_deps:bazel_skylib.bzl", "bazel_skylib_deps")
+
 # Repositories in this file have been tested with Bazel 0.26.0.
 
 def _maybe(repo, name, **kwargs):
@@ -8,15 +11,15 @@ def _maybe(repo, name, **kwargs):
         repo(name = name, **kwargs)
 
 def bazel_skylib():
-    _maybe(
-        http_archive,
-        name = "bazel_skylib",
-        url = "https://github.com/bazelbuild/bazel-skylib/releases/download/0.9.0/bazel_skylib-0.9.0.tar.gz",
-        sha256 = "1dde365491125a3db70731e25658dfdd3bc5dbdfd11b840b3e987ecf043c7ca0",
-    )
-    load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-    # TODO(aiuto): This registers toolchains. Is it safe to reregister?
-    bazel_skylib_workspace()
+    if not native.existing_rule("bazel_skylib"):
+        http_archive(
+            name = "bazel_skylib",
+            url = "https://github.com/bazelbuild/bazel-skylib/releases/download/0.9.0/bazel_skylib-0.9.0.tar.gz",
+            sha256 = "1dde365491125a3db70731e25658dfdd3bc5dbdfd11b840b3e987ecf043c7ca0",
+        )
+        # TODO(aiuto): We should be able to call bazel_skylib_deps() here. That would
+        # TODO(aiuto): register the toolchains. But we can not be
+        # TODO(aiuto): bazel_skylib_deps()
 
 def bazel_skydoc():
     _maybe(
@@ -24,6 +27,7 @@ def bazel_skydoc():
         name = "io_bazel_skydoc",
         url = "https://github.com/bazelbuild/skydoc/archive/0.3.0.tar.gz",
         sha256 = "c2d66a0cc7e25d857e480409a8004fdf09072a1bd564d6824441ab2f96448eea",
+        strip_prefix = "skydoc-0.3.0",
    )
 
 

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -11,10 +11,12 @@ def bazel_skylib():
     _maybe(
         http_archive,
         name = "bazel_skylib",
-        url = "https://github.com/bazelbuild/bazel-skylib/releases/download/0.8.0/bazel-skylib.0.8.0.tar.gz",
-        sha256 = "2ef429f5d7ce7111263289644d233707dba35e39696377ebab8b0bc701f7818e",
+        url = "https://github.com/bazelbuild/bazel-skylib/releases/download/0.9.0/bazel_skylib-0.9.0.tar.gz",
+        sha256 = "1dde365491125a3db70731e25658dfdd3bc5dbdfd11b840b3e987ecf043c7ca0",
     )
-
+    load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+    # TODO(aiuto): This registers toolchains. Is it safe to reregister?
+    bazel_skylib_workspace()
 
 def bazel_skydoc():
     _maybe(


### PR DESCRIPTION
Update skylib to 0.9
Add examples/skydoc.

This demonstrates a serious problem for using rule sets which need to register toolchains.
You can not load() their method to register the toolchains except from a macro that is not loaded until after the repository is conditionally brought in.  