### PR TITLE
Remove rules_java_dependencies() from rules_java setup

### DIFF
--- a/setup/rules_java.bzl
+++ b/setup/rules_java.bzl
@@ -1,5 +1,4 @@
-load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
+load("@rules_java//java:repositories.bzl", "rules_java_toolchains")
 
 def rules_java_setup():
-    rules_java_dependencies()
     rules_java_toolchains()


### PR DESCRIPTION
As of https://github.com/bazelbuild/bazel-federation/pull/20 all required dependencies are already fetched via rules_java_deps() in repositories.bzl