### PR TITLE
Add more repository setup rules so that everything is uniform.

### DIFF
--- a/setup/bazel_stardoc.bzl
+++ b/setup/bazel_stardoc.bzl
@@ -1,0 +1,6 @@
+# Stardoc does not have any of its own setup, but we do have to make
+# sure we run the setup for all our dependencies.
+load("@bazel_federation//setup:rules_java.bzl", "rules_java_setup")
+
+def bazel_stardoc_setup():
+    rules_java_setup()

--- a/setup/rules_pkg.bzl
+++ b/setup/rules_pkg.bzl
@@ -1,0 +1,2 @@
+def rules_pkg_setup():
+    pass

--- a/tests/integration/WORKSPACE
+++ b/tests/integration/WORKSPACE
@@ -9,22 +9,29 @@ load("@bazel_federation//:repositories.bzl",
      "bazel_skylib",
      "bazel_stardoc",
      "rules_cc",
+     "rules_java",
+     "rules_pkg",
 )
 
 rules_cc()
 load("@bazel_federation//setup:rules_cc.bzl", "rules_cc_setup")
 rules_cc_setup()
 
+rules_java()
+load("@bazel_federation//setup:rules_java.bzl", "rules_java_setup")
+rules_java_setup()
+
 bazel_skylib()
-# We can not even return the repo name and metho from the bazel_skylib()
+# We can not even return the repo name and method from the bazel_skylib()
 # method, because load takes string literals only, not variables that can be
 # a string. See /repositories.bzl for more info.
 load("@bazel_federation//setup:bazel_skylib.bzl", "bazel_skylib_setup")
 bazel_skylib_setup()
 
 bazel_stardoc()
-# This is another usability problem. stardoc uses java, but why should I have
-# to know that as a user. I have to explicitly add this
-# this a the workspace
-load("@bazel_federation//setup:rules_java.bzl", "rules_java_setup")
-rules_java_setup()
+load("@bazel_federation//setup:bazel_stardoc.bzl", "bazel_stardoc_setup")
+bazel_stardoc_setup()
+
+rules_pkg()
+load("@bazel_federation//setup:rules_pkg.bzl", "rules_pkg_setup")
+rules_pkg_setup()


### PR DESCRIPTION
bazel_stardoc_setup() is the interesting one.
Since Java is a dependency we want to make sure that it gets initialized.
We probably should make the setup functions guard themselves with an initialized flag. But yech, that has to pollute the global namespace.