### PR TITLE
Add python & pkg_tar

### DIFF
--- a/tests/integration/WORKSPACE
+++ b/tests/integration/WORKSPACE
@@ -11,6 +11,7 @@ load("@bazel_federation//:repositories.bzl",
      "rules_cc",
      "rules_java",
      "rules_pkg",
+     "rules_python",
 )
 
 rules_cc()
@@ -20,6 +21,11 @@ rules_cc_setup()
 rules_java()
 load("@bazel_federation//setup:rules_java.bzl", "rules_java_setup")
 rules_java_setup()
+
+rules_python()
+load("@bazel_federation//setup:rules_python.bzl", "rules_python_setup")
+rules_python_setup()
+
 
 bazel_skylib()
 # We can not even return the repo name and method from the bazel_skylib()

--- a/tests/integration/hello_bazel/BUILD
+++ b/tests/integration/hello_bazel/BUILD
@@ -2,6 +2,7 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@io_bazel_skydoc//stardoc:stardoc.bzl", "stardoc")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_binary")
 load("@rules_java//java:defs.bzl", "java_library", "java_binary")
+load("@rules_python//python:defs.bzl", "py_binary")
 
 load(":my_rule.bzl", "my_rule")
 
@@ -58,4 +59,10 @@ java_binary(
 java_library(
     name = "hello_lib_java",
     srcs = ["HelloLib.java"],
+)
+
+py_binary(
+    name = "hello_in_python",
+    srcs = ["hello.py"],
+    main = "hello.py",
 )

--- a/tests/integration/hello_bazel/BUILD
+++ b/tests/integration/hello_bazel/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_skydoc//stardoc:stardoc.bzl", "stardoc")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_binary")
 load("@rules_java//java:defs.bzl", "java_library", "java_binary")
 load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 load(":my_rule.bzl", "my_rule")
 
@@ -65,4 +66,13 @@ py_binary(
     name = "hello_in_python",
     srcs = ["hello.py"],
     main = "hello.py",
+)
+
+pkg_tar(
+    name = "tarball",
+    srcs = glob(["**"]) + [
+        "//:srcs",
+    ],
+    strip_prefix = "/",
+    package_dir = "federation/sample",
 )

--- a/tests/integration/hello_bazel/README.md
+++ b/tests/integration/hello_bazel/README.md
@@ -1,0 +1,32 @@
+# Hello world in all the languages
+
+
+## Things to try
+
+```
+bazel build :*
+bazel run :hello_in_c
+bazel run :HelloinJava
+bazel run :hello_in_python
+bazel build :tarball
+tar tvf ../bazel-bin/hello_bazel/tarball.tar
+```
+
+The tarball content should be
+
+```
+drwxr-xr-x 0/0               0 1999-12-31 19:00 ./
+drwxr-xr-x 0/0               0 1999-12-31 19:00 ./federation/
+drwxr-xr-x 0/0               0 1999-12-31 19:00 ./federation/sample/
+drwxr-xr-x 0/0               0 1999-12-31 19:00 ./federation/sample/hello_bazel/
+-r-xr-xr-x 0/0            1435 1999-12-31 19:00 ./federation/sample/hello_bazel/BUILD
+-r-xr-xr-x 0/0             198 1999-12-31 19:00 ./federation/sample/hello_bazel/Hello.java
+-r-xr-xr-x 0/0              93 1999-12-31 19:00 ./federation/sample/hello_bazel/HelloLib.java
+-r-xr-xr-x 0/0             142 1999-12-31 19:00 ./federation/sample/hello_bazel/hello.cc
+-r-xr-xr-x 0/0             132 1999-12-31 19:00 ./federation/sample/hello_bazel/hello.py
+-r-xr-xr-x 0/0              95 1999-12-31 19:00 ./federation/sample/hello_bazel/hello_lib.cc
+-r-xr-xr-x 0/0              50 1999-12-31 19:00 ./federation/sample/hello_bazel/hello_lib.h
+-r-xr-xr-x 0/0             653 1999-12-31 19:00 ./federation/sample/hello_bazel/my_rule.bzl
+-r-xr-xr-x 0/0             143 1999-12-31 19:00 ./federation/sample/BUILD
+-r-xr-xr-x 0/0            1098 1999-12-31 19:00 ./federation/sample/WORKSPACE
+```

--- a/tests/integration/hello_bazel/hello.py
+++ b/tests/integration/hello_bazel/hello.py
@@ -1,0 +1,11 @@
+"""hello bazel"""
+
+from __future__ import print_function
+
+
+def main():
+  print('Hello bazel')
+
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
Add hellobazel in python to integration example
￼
Put the sources in a tarball to show pkg_tar. Since pkg_tar uses python, this helps verify that py_binary works with pkg_tar