### PR TITLE
rules_python_setup: default use_pip to false

### DIFF
--- a/setup/rules_python.bzl
+++ b/setup/rules_python.bzl
@@ -1,5 +1,5 @@
 load("@rules_python//python:pip.bzl", "pip_repositories")
 
-def rules_python_setup(use_pip=True):
+def rules_python_setup(use_pip=False):
     if use_pip:
         pip_repositories()


### PR DESCRIPTION
It seems more conservative to opt out of a ruleset by default unless specifically requested. Users of Python rules who don't need packaging support won't necessarily know to disable this flag for a more minimal build. In any case, we'll make the usage clear in the rules_python readme once the federation has settled.

We could flip this back to true at some point in the future if we believe the packaging rules are stable.