### PR TITLE
Use federation-compliant versions of rules_java and rules_python

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -176,8 +176,10 @@ def rules_java():
     maybe(
         http_archive,
         name = "rules_java",
-        url = "https://github.com/bazelbuild/rules_java/releases/download/0.1.0/rules_java-0.1.0.tar.gz",
-        sha256 = "52423cb07384572ab60ef1132b0c7ded3a25c421036176c0273873ec82f5d2b2",
+        url = "https://github.com/bazelbuild/rules_java/archive/d7bf804c8731edd232cb061cb2a9fe003a85d8ee.zip",
+        sha256 = "dc6b247b0bc61120e6c2bfe314c7ed5b19a3a5d5d3a3f8e9acf3ea8b4fb05c7b",
+        strip_prefix = "rules_java-d7bf804c8731edd232cb061cb2a9fe003a85d8ee",
+        type = "zip",
     )
 
 def rules_nodejs_deps():
@@ -216,9 +218,9 @@ def rules_python():
     maybe(
         http_archive,
         name = "rules_python",
-        strip_prefix = "rules_python-4b84ad270387a7c439ebdccfd530e2339601ef27",
-        url = "https://github.com/bazelbuild/rules_python/archive/4b84ad270387a7c439ebdccfd530e2339601ef27.tar.gz",
-        sha256 = "e5470e92a18aa51830db99a4d9c492cc613761d5bdb7131c04bd92b9834380f6",
+        strip_prefix = "rules_python-fe5e0fa208f4fc4e469a960fe8c0d46394a21c21",
+        url = "https://github.com/bazelbuild/rules_python/archive/fe5e0fa208f4fc4e469a960fe8c0d46394a21c21.tar.gz",
+        sha256 = "59d82d1d8b21d37d3df9b92712487d8b055a39d77eaec569dff857ffcbc63971",
     )
 
 def rules_rust_deps():


### PR DESCRIPTION
We're already using the right version of rules_cc. Bazel-skylib isn't ready yet since the corresponding PR is still pending: https://github.com/bazelbuild/bazel-skylib/pull/182