### PR TITLE
Fix rules_python presubmit config

### DIFF
--- a/.bazelci/rules_python.yml
+++ b/.bazelci/rules_python.yml
@@ -1,22 +1,22 @@
+targets: &targets
+  build_targets:
+  - "@rules_python//examples/..."
+  - "@rules_python//experimental/..."
+  - "@rules_python//python/..."
+  - "@rules_python//rules_python/..."
+  - "@rules_python//tools/..."
+  test_targets:
+  - "@rules_python//..."
 platforms:
   macos:
-    build_targets:
-    - '@rules_python//...'
     setup:
     - python3.7 create_project_workspace.py --project=rules_python
-    test_targets:
-    - '@rules_python//...'
+    <<: *targets
   ubuntu1604:
-    build_targets:
-    - '@rules_python//...'
     setup:
     - python3.6 create_project_workspace.py --project=rules_python
-    test_targets:
-    - '@rules_python//...'
+    <<: *targets
   ubuntu1804:
-    build_targets:
-    - '@rules_python//...'
     setup:
     - python3.6 create_project_workspace.py --project=rules_python
-    test_targets:
-    - '@rules_python//...'
+    <<: *targets


### PR DESCRIPTION
The new version matches the current rules_python presubmit configuration from https://github.com/bazelbuild/rules_python/pull/213.