### PR TITLE
Disable another failing rules_python test

### DIFF
--- a/.bazelci/rules_python.yml
+++ b/.bazelci/rules_python.yml
@@ -13,6 +13,8 @@ targets: &targets
   - "@rules_python//..."
   # TODO(https://github.com/bazelbuild/rules_python/issues/225): enable test once fixed
   - "-@rules_python//experimental/examples/wheel/..."
+  # TODO(https://github.com/bazelbuild/rules_python/issues/227): enable test once fixed
+  - "-@rules_python//rules_python:whl_test"
 platforms:
   macos:
     setup:


### PR DESCRIPTION
Exmaple: https://buildkite.com/bazel/bazel-federation/builds/21#3311863a-86e8-4403-8bc6-fc7e85b79ae1
Cause: https://github.com/bazelbuild/rules_python/issues/227