### PR TITLE
Use new rules_python version with working whl_test

### DIFF
--- a/.bazelci/rules_python.yml
+++ b/.bazelci/rules_python.yml
@@ -6,15 +6,13 @@ targets: &targets
   # TODO(https://github.com/bazelbuild/rules_python/issues/225): enable test once fixed
   - "-@rules_python//experimental/examples/wheel/..."
   - "@rules_python//python/..."
-  - "@rules_python//rules_python/..."
+  - "@rules_python//packaging/..."
   - "@rules_python//tools/..."
   test_targets:
   - "--"
   - "@rules_python//..."
   # TODO(https://github.com/bazelbuild/rules_python/issues/225): enable test once fixed
   - "-@rules_python//experimental/examples/wheel/..."
-  # TODO(https://github.com/bazelbuild/rules_python/issues/227): enable test once fixed
-  - "-@rules_python//rules_python:whl_test"
 platforms:
   macos:
     setup:

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -220,9 +220,9 @@ def rules_python():
     maybe(
         http_archive,
         name = "rules_python",
-        strip_prefix = "rules_python-fe5e0fa208f4fc4e469a960fe8c0d46394a21c21",
-        url = "https://github.com/bazelbuild/rules_python/archive/fe5e0fa208f4fc4e469a960fe8c0d46394a21c21.tar.gz",
-        sha256 = "59d82d1d8b21d37d3df9b92712487d8b055a39d77eaec569dff857ffcbc63971",
+        strip_prefix = "rules_python-9d68f24659e8ce8b736590ba1e4418af06ec2552",
+        url = "https://github.com/bazelbuild/rules_python/archive/9d68f24659e8ce8b736590ba1e4418af06ec2552.tar.gz",
+        sha256 = "b5bab4c47e863e0fbb77df4a40c45ca85f98f5a2826939181585644c9f31b97b",
     )
 
 def rules_rust_deps():


### PR DESCRIPTION
This commit also updates the presubmit configuration to a) enable the previously failing test again and b) reflect the fact that a package was renamed.