### PR TITLE
Take out the cycle between federation and others

### DIFF
--- a/.bazelci/rules_java.yml
+++ b/.bazelci/rules_java.yml
@@ -1,28 +1,28 @@
 tasks:
   macos:
     build_targets:
-    - '@rules_java//...'
+    - '@rules_java//java/...'
     setup:
     - python3.7 create_project_workspace.py --project=rules_java
   ubuntu1604:
     build_targets:
-    - '@rules_java//...'
+    - '@rules_java//java/...'
     setup:
     - python3.6 create_project_workspace.py --project=rules_java
   ubuntu1804:
     build_targets:
-    - '@rules_java//...'
+    - '@rules_java//java/...'
     setup:
     - python3.6 create_project_workspace.py --project=rules_java
-  ubuntu1804_nojava:
+  ubuntu1804_nojava/
     build_flags:
     - --javabase=@openjdk11_linux_archive//:runtime
     build_targets:
-    - '@rules_java//...'
+    - '@rules_java//java/...'
     setup:
     - python3.6 create_project_workspace.py --project=rules_java
   windows:
     build_targets:
-    - '@rules_java//...'
+    - '@rules_java//java/...'
     setup:
     - python.exe create_project_workspace.py --project=rules_java

--- a/examples/stardoc/WORKSPACE
+++ b/examples/stardoc/WORKSPACE
@@ -11,15 +11,9 @@ load("@bazel_federation//:repositories.bzl",
 )
 
 bazel_skylib()
-# We can not even return the repo name and metho from the bazel_skylib()
-# method, because load takes string literals only, not variables that can be
-# a string. See /repositories.bzl for more info.
 load("@bazel_federation//setup:bazel_skylib.bzl", "bazel_skylib_setup")
 bazel_skylib_setup()
 
 bazel_stardoc()
-# This is another usability problem. stardoc uses java, but why should I have
-# to know that as a user. I have to explicitly add this
-# this a the workspace
-load("@bazel_federation//setup:rules_java.bzl", "rules_java_setup")
-rules_java_setup()
+load("@bazel_federation//setup:bazel_stardoc.bzl", "bazel_stardoc_setup")
+bazel_stardoc_setup()

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -1,20 +1,11 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("//:java_repositories.bzl", "remote_jdk11_repos", "java_tools_javac11_repos")
-load("//:third_party_repositories.bzl", "abseil_py", "zlib", "org_golang_x_tools", "org_golang_x_sys", "six", "jinja2", "mistune", "markupsafe")
 
 # WARNING: The following definitions are placeholders since none of the projects have been tested at the versions listed in this file.
 # Please do not use them (yet). Future commits to this file will set the proper versions and ensure that all dependencies are correct.
 
-
-def bazel():
-    maybe(
-        git_repository,
-        name = "io_bazel",
-        remote = "https://github.com/bazelbuild/bazel.git",
-        commit = "c689bf93917ad0efa8100b3a0fe1b43f1f1a1cdf",  # Mar 19, 2019
-    )
+# Repositories in this file have been tested with Bazel 0.26.0.
 
 def bazel_buildtools_deps():
     bazel_skylib()
@@ -29,18 +20,6 @@ def bazel_buildtools():
         url = "https://github.com/bazelbuild/buildtools/archive/f27d1753c8b3210d9e87cdc9c45bc2739ae2c2db.zip",
     )
 
-def bazel_gazelle_deps():
-    rules_go()
-    # TODO(fweikert): add all gazelle dependencies to the federation
-
-def bazel_gazelle():
-    bazel_gazelle_deps()
-    maybe(
-        http_archive,
-        name = "bazel_gazelle",
-        sha256 = "7949fc6cc17b5b191103e97481cf8889217263acf52e00b560683413af204fcb",
-        urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.16.0/bazel-gazelle-0.16.0.tar.gz"],
-    )
 
 def bazel_integration_testing_deps():
     pass  # TODO(fweikert): examine dependencies and add them, if necessary
@@ -90,12 +69,14 @@ def bazel_skylib():
     # load("@bazel_federation//setup:bazel_skylib.bzl", "bazel_skylib_setup")
     # bazel_skylib_setup()
 
+
 def bazel_stardoc_deps():
     rules_nodejs()
     rules_sass()
 
 def bazel_stardoc():
-    bazel_stardoc_deps()
+    # bazel_stardoc_deps()
+    rules_java()
     maybe(
         http_archive,
         name = "io_bazel_skydoc",
@@ -106,7 +87,7 @@ def bazel_stardoc():
 
 # TODO(fweikert): delete this function if it's not needed by the protobuf project itself.
 def protobuf_deps():
-    zlib()
+    # zlib()
     protobuf_javalite()
 
 def protobuf():
@@ -137,7 +118,7 @@ def protobuf_javalite():
 def rules_cc_deps():
     bazel_skylib()
 
-def rules_cc():
+def XXrules_cc():
     rules_cc_deps()
     maybe(
         http_archive,
@@ -147,6 +128,18 @@ def rules_cc():
         strip_prefix = "rules_cc-624b5d59dfb45672d4239422fa1e3de1822ee110",
         type = "zip",
     )
+
+def rules_cc():
+    bazel_skylib()
+    maybe(
+        http_archive,
+        name = "rules_cc",
+        url = "https://github.com/bazelbuild/rules_cc/archive/b7fe9697c0c76ab2fd431a891dbb9a6a32ed7c3e.zip",
+        sha256 = "67412176974bfce3f4cf8bdaff39784a72ed709fc58def599d1f68710b58d68b",
+        strip_prefix = "rules_cc-b7fe9697c0c76ab2fd431a891dbb9a6a32ed7c3e",
+        type = "zip",
+    )
+
 
 # TODO(fweikert): check deps
 def rules_go_deps():
@@ -166,9 +159,69 @@ def rules_go():
         sha256 = "f04d2373bcaf8aa09bccb08a98a57e721306c8f6043a2a0ee610fd6853dcde3d",
     )
 
+
+def org_golang_x_tools():
+    maybe(
+        http_archive,
+        name = "org_golang_x_tools",
+        # master^1, as of 2018-11-02 (master is currently broken)
+        urls = ["https://codeload.github.com/golang/tools/zip/92b943e6bff73e0dfe9e975d94043d8f31067b06"],
+        strip_prefix = "tools-92b943e6bff73e0dfe9e975d94043d8f31067b06",
+        type = "zip",
+        patches = [
+            "@io_bazel_rules_go//third_party:org_golang_x_tools-gazelle.patch",
+            "@io_bazel_rules_go//third_party:org_golang_x_tools-extras.patch",
+        ],
+        patch_args = ["-p1"],
+        # gazelle args: -go_prefix golang.org/x/tools
+    )
+
+def org_golang_x_sys():
+    maybe(
+        git_repository,
+        name = "org_golang_x_sys",
+        remote = "https://github.com/golang/sys",
+        commit = "e4b3c5e9061176387e7cea65e4dc5853801f3fb7",  # master as of 2018-09-28
+        patches = ["@io_bazel_rules_go//third_party:org_golang_x_sys-gazelle.patch"],
+        patch_args = ["-p1"],
+        # gazelle args: -go_prefix golang.org/x/sys
+    )
+
+def io_bazel_rules_go():
+    org_golang_x_tools()
+    org_golang_x_sys()
+    http_archive(
+        name = "io_bazel_rules_go",
+        sha256 = "7be7dc01f1e0afdba6c8eb2b43d2fa01c743be1b9273ab1eaf6c233df078d705",
+        urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.16.5/rules_go-0.16.5.tar.gz"],
+    )
+
+
+def bazel_gazelle_deps():
+    # TODO(fweikert): add all gazelle dependencies to the federation
+    rules_go()
+
+def bazel_gazelle():
+    bazel_gazelle_deps()
+    http_archive(
+        name = "bazel_gazelle",
+        sha256 = "7949fc6cc17b5b191103e97481cf8889217263acf52e00b560683413af204fcb",
+        urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.16.0/bazel-gazelle-0.16.0.tar.gz"],
+    )
+
+
+def com_github_bazelbuild_buildtools():
+    http_archive(
+        name = "com_github_bazelbuild_buildtools",
+        strip_prefix = "buildtools-0.20.0",
+        url = "https://github.com/bazelbuild/buildtools/archive/0.20.0.zip",
+        sha256 = "7b46f95f1df24a62dbe1953cb7820f4170525f72b93a7f9fe414e027a3151128",
+    )
+
 def rules_java_deps():
-    remote_jdk11_repos()
-    java_tools_javac11_repos()
+    # TODO(aiuto): Java dependencies are currently brought in through
+    # rules_java_setup(). As Java migrates from native to starlark, we should
+    # bring in the dependencies in a formal way. Right now it churns too much.
     bazel_skylib()
 
 def rules_java():
@@ -194,12 +247,48 @@ def rules_nodejs():
         sha256 = "abcf497e89cfc1d09132adfcd8c07526d026e162ae2cb681dcb896046417ce91",
     )
 
-def rules_pkg_deps():
-    abseil_py()
-    six()
+
+# The @federation markers are an experiment in how to pick up dependency stanzas
+# from the rule sets. Each rule set should have a deps.bzl file. Inside those,
+# there will be the @federation markers. Those must be designed so they can
+# be extracted and dropped directly into this file, replacing the same stanza.
+
+# @federation: BEGIN @rules_pkg
+# TODO: ptr to where this was extracted from
+# https://github.com/bazelbuild/rules_pkg/pkg/deps.bzl
+def abseil_py():
+    six_archive()
+    maybe(
+        http_archive,
+        name = "abseil_py",
+        urls = [
+            "https://github.com/abseil/abseil-py/archive/pypi-v0.7.1.tar.gz",
+        ],
+        sha256 = "3d0f39e0920379ff1393de04b573bca3484d82a5f8b939e9e83b20b6106c9bbe",
+        strip_prefix = "abseil-py-pypi-v0.7.1",
+    )
+
+def six_archive():
+    maybe(
+        http_archive,
+        name = "six_archive",
+        urls = [
+            "http://mirror.bazel.build/pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz",
+            "https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz",
+        ],
+        sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",
+        strip_prefix = "six-1.10.0",
+        build_file = "@abseil_py//third_party:six.BUILD"
+    )
+
+
+def rules_pkg_register_toolchains():
+    pass
+
 
 def rules_pkg():
-    rules_pkg_deps()
+    abseil_py()
+    six_archive()
     maybe(
         http_archive,
         name = "rules_pkg",
@@ -209,6 +298,8 @@ def rules_pkg():
         ],
         sha256 = "04c1eab736f508e94c297455915b6371432cbc4106765b5252b444d1656db051",
     )
+
+# @federation: END @rules_pkg
 
 def rules_python_deps():
     pass
@@ -256,6 +347,17 @@ def rules_scala():
     rules_scala_deps()
     maybe(
         http_archive,
+        name = "io_bazel_rules_scala",
+        strip_prefix = "rules_scala-300b4369a0a56d9e590d9fea8a73c3913d758e12",
+        type = "zip",
+        # commit from 2019-05-27
+        url = "https://github.com/bazelbuild/rules_scala/archive/300b4369a0a56d9e590d9fea8a73c3913d758e12.zip",
+        sha256 = "7f35ee7d96b22f6139b81da3a8ba5fb816e1803ed097f7295b85b7a56e4401c7",
+    )
+
+def io_bazel_rules_scala():
+    bazel_skylib()
+    http_archive(
         name = "io_bazel_rules_scala",
         strip_prefix = "rules_scala-300b4369a0a56d9e590d9fea8a73c3913d758e12",
         type = "zip",

--- a/setup/rules_java.bzl
+++ b/setup/rules_java.bzl
@@ -1,4 +1,5 @@
-load("@rules_java//java:repositories.bzl", "rules_java_toolchains")
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
 
 def rules_java_setup():
+    rules_java_dependencies()
     rules_java_toolchains()

--- a/tests/integration/hello_bazel/README.md
+++ b/tests/integration/hello_bazel/README.md
@@ -6,7 +6,7 @@
 ```
 bazel build :*
 bazel run :hello_in_c
-bazel run :HelloinJava
+bazel run :HelloInJava
 bazel run :hello_in_python
 bazel build :tarball
 tar tvf ../bazel-bin/hello_bazel/tarball.tar

--- a/utils.py
+++ b/utils.py
@@ -14,9 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
+
 import sys
 
 
 def eprint(msg):
     """Print to stderr and flush (just in case)."""
-    print(msg, flush=True, file=sys.stderr)
+    print(msg, file=sys.stderr)
+    sys.stderr.flush()


### PR DESCRIPTION
We can not have any load() methods in repositories.bzl that reach outside of the federation because then people have to download and load even if they do not use the rule,.

Fix examples/stardoc
fix examples/rules_pkg
fix test/integegration/hello_bazel
fix .bazelci/rules_javaa

I did not get to test go.