### PR TITLE
load rules_java deps from rules_java

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -1,7 +1,6 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("//:java_repositories.bzl", "remote_jdk11_repos", "java_tools_javac11_repos")
 load("//:third_party_repositories.bzl", "zlib", "org_golang_x_tools", "org_golang_x_sys", "jinja2", "mistune", "markupsafe")
 
 # WARNING: The following definitions are placeholders since none of the projects have been tested at the versions listed in this file.
@@ -169,12 +168,23 @@ def rules_go():
     )
 
 def rules_java_deps():
-    remote_jdk11_repos()
-    java_tools_javac11_repos()
+    # TODO(aiuto): When rules_java stabalizes, reference the deps directly.
+    # rules_java is going to be changing for the next few months. While that
+    # is happening we let rules_java_setup() bring in the deps. This allows
+    # use to quicky update rules_java without havig to update all of the deps
+    # tree which is only used by Java.
     bazel_skylib()
 
 def rules_java():
     rules_java_deps()
+    # TODO(aiuto): After https://github.com/bazelbuild/rules_java/pull/14 is
+    # submitted, produce a release and point to that new one.
+    #maybe(
+    #    http_archive,
+    #    name = "rules_java",
+    #    url = "https://github.com/bazelbuild/rules_java/releases/download/0.1.0/rules_java-0.1.0.tar.gz",
+    #    sha256 = "TBD",
+    #)
     maybe(
         http_archive,
         name = "rules_java",

--- a/setup/rules_java.bzl
+++ b/setup/rules_java.bzl
@@ -1,4 +1,5 @@
-load("@rules_java//java:repositories.bzl", "rules_java_toolchains")
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
 
 def rules_java_setup():
+    rules_java_dependencies()
     rules_java_toolchains()


### PR DESCRIPTION
 Instead of loading all the rules_java deps explicitly in the federation,
call back to rules_java during rules_java_setup to load them.

This allows rules_java to rapidly update the dependencies in the period
of change between now and the full migration to Starlark native.
When they have a change in dependencies we can update a single
point in the federation without having to track ever changing deps.

When the deps become stable OR we have to pin one because of a
conflict with other rules, we can move to loading them explicitly.