### PR TITLE
Re-enable fixed rules_python targets

### DIFF
--- a/.bazelci/rules_python.yml
+++ b/.bazelci/rules_python.yml
@@ -3,8 +3,6 @@ targets: &targets
   - "--"
   - "@rules_python//examples/..."
   - "@rules_python//experimental/..."
-  # TODO(https://github.com/bazelbuild/rules_python/issues/225): enable test once fixed
-  - "-@rules_python//experimental/examples/wheel/..."
   - "@rules_python//python/..."
   - "@rules_python//packaging/..."
   - "@rules_python//tools/..."

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -229,9 +229,9 @@ def rules_python():
     maybe(
         http_archive,
         name = "rules_python",
-        strip_prefix = "rules_python-9d68f24659e8ce8b736590ba1e4418af06ec2552",
-        url = "https://github.com/bazelbuild/rules_python/archive/9d68f24659e8ce8b736590ba1e4418af06ec2552.tar.gz",
-        sha256 = "b5bab4c47e863e0fbb77df4a40c45ca85f98f5a2826939181585644c9f31b97b",
+        strip_prefix = "rules_python-e0644961d74b9bbb8a975a01bebb045abfd5d1bd",
+        url = "https://github.com/bazelbuild/rules_python/archive/e0644961d74b9bbb8a975a01bebb045abfd5d1bd.tar.gz",
+        sha256 = "a3c516f4ed620a2c5a2b4edd31150c86023322492852f96a40d1ee4730d6e060",
     )
 
 def rules_rust_deps():


### PR DESCRIPTION
This rolls back #45, now that bazelbuild/rules_python#225 has been fixed.

CI coverage for the failure has also been added to rules_python in
bazelbuild/rules_python#226.