### PR TITLE
Fix the top level doc pointer. run formatter on the docs pages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,4 +104,4 @@ The CI configuration for each member project is based on their regular presubmit
 
 ## More information
 
-[Documentation](https://bazldocs/index.md)
+[Documentation](https://bazelbuild.github.io/bazel-federation/)

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,59 +1,75 @@
 # Bazel Federation - About
 
-The Bazel Federation is a set of rules at versions that have been tested together to ensure interoperability.
+The Bazel Federation is a set of rules at versions that have been tested
+together to ensure interoperability.
 
-*NOTE: This document is a work in progress.  It is very much incomplete.*
+*NOTE: This document is a work in progress. It is very much incomplete.*
 
 ## TL;DR;
 
--  A Federation release is a promise that we tested a specific Bazel version along with a set of rules at their specific versions. It is little more than a set of workspace methods that gets you that tested set.
--  There will be a Federation track for each long term support Bazel track. You might stick with the Federation that includes Bazel 1.0.0 for a year or more.
-   -   As rules add features which back port to older Bazel, there can be Federation patch releases for that track.
-   -   If rules evolve to require newer versions of Bazel, they will only be
-       included in Federation releases tracking the newer Bazel releases.
+-   A Federation release is a promise that we tested a specific Bazel version
+    along with a set of rules at their specific versions. It is little more than
+    a set of workspace methods that gets you that tested set.
+-   There will be a Federation track for each long term support Bazel track. You
+    might stick with the Federation that includes Bazel 1.0.0 for a year or
+    more.
+    -   As rules add features which back port to older Bazel, there can be
+        Federation patch releases for that track.
+    -   If rules evolve to require newer versions of Bazel, they will only be
+        included in Federation releases tracking the newer Bazel releases.
+
+## What is a Federation release?
+
+The most obvious goal of the Federation is give users greater assurance that a
+set of rules works with a particular Bazel release. We give that assurance by
+integration testing them against each other. We encourage integration tests that
+span rule sets. This is especially important as the number of interdependencies
+of rules grow.
+
+An equally important goal is that if a user adopts a Federation version today,
+_they can continue to use it for an extended period of time_. This does not mean
+that Bazel (or rules) can never have backwards incompatible changes. It means
+that the Federation is a mechanism to allow a user to continue to use an older
+version of Bazel along with rules that are being updated. It would be
+unreasonable to insist that all rules remain backwards compatible with all
+previous Bazel versions - that is just too much work. Instead, a Federation
+around an older version of Bazel can be updated to include new versions of some
+rules, as long as the basic promise that all the rules  in the Federation work
+together is kept.
+
+This implies a freedom that Bazel maintainers and rule creators should have.
+They may update their rules in ways totally incompatible with earlier versions
+of Bazel. If users want to make use of those new features, they will have to
+update to a new Federation release that includes the updated rule(s). While this
+may sound like any Bazel release can break arbitrary things it is significantly
+different.
+
+-   There are update paths from old Bazel versions to newer rules providing they
+    interoperate in an old Federation version
+-   When you need a new rule capability that depends on a breaking change in
+    Bazel, the Federation release for that Bazel version is guidance about all
+    the rules which must be updated. Users are not left on their own to
+    determine what interoperates. This is the most important user facing
+    promise. It allows you to scope the effort to update rather than do it by
+    trial and error.
+
+While it seems that we have granted rule owners the right to never look at
+backwards compatibility, we want to aim for the best user experience. Rule
+owners should have some commitments to the community:
+
+-   as they add new backwards compatible features they should update older
+    federation versions to include their new rule.
+-   if they create breaking changes, they must work with downstream rules to
+    make sure they interoperate in the upcoming Federation releases.
 
 ## Some principles
 
 -   The idea of downloading rules at head is strongly unrecommended. Federation
     releases will only point to explicit rule releases.
--   Rule authors are not obliged to keep their rules working with older versions of Bazel.
-
-
-## What is a Federation release?
-
-The most obvious goal of the Federation is give users greater assurance
-that a set of rules works with a particular Bazel release. We give that
-assurance by integration testing them against each other. We encourage
-integration tests that span rule sets. This is especially important as
-the number of interdependencies of rules grow.
-
-An equally important goal is that if a user adopts a Federation version
-today, _they can continue to use it for an extended period of time_. This
-does not mean that Bazel (or rules) can never have backwards incompatible
-changes. It means that the Federation is a mechanism to allow a user to continue to
-use an older version of Bazel along with rules that are being updated. It
-would be unreasonable to insist that all rules remain backwards compatible
-with all previous Bazel versions - that is just too much work. Instead, a
-Federation around an older version of Bazel can be updated to include new
-versions of some rules, as long as the basic promise that all the rules 
-in the Federation work together is kept.
-
-This implies a freedom that Bazel maintainers and rule creators should
-have. They may update their rules in ways totally incompatible with
-earlier versions of Bazel. If users want to make use of those new
-features, they will have to update to a new Federation release that
-includes the updated rule(s). While this may sound like any Bazel release
-can break arbitrary things it is significantly different.
-
--   There are update paths from old Bazel versions to newer rules providing they interoperate in an old Federation version
--   When you need a new rule capability that depends on a breaking change in Bazel, the Federation release for that Bazel version is guidance about all the rules which must be updated. Users are not left on their own to determine what interoperates. This is the most important user facing promise. It allows you to scope the effort to update rather than do it by trial and error.
-
-While it seems that we have granted rule owners the right to never look at backwards compatibility, we want to aim for the best user experience. Rule owners should have some commitments to the community:
-
--   as they add new backwards compatible features they should update older federation versions to include their new rule.
--   if they create breaking changes, they must work with downstream rules to make sure they interoperate in the upcoming Federation releases.
-
+-   Rule authors are not obliged to keep their rules working with older versions
+    of Bazel.
 
 ## Things to read.
 
--  [Example of how multiple Federation releases co-exist as Bazel and rules evolve](https://docs.google.com/spreadsheets/d/1JOqCREzfctH_ITO8Cl4rDHEWI9ylR6FgUksMpDhZeDI/edit#gid=0)
+-   [Example of how multiple Federation releases co-exist as Bazel and rules
+    evolve](https://docs.google.com/spreadsheets/d/1JOqCREzfctH_ITO8Cl4rDHEWI9ylR6FgUksMpDhZeDI/edit#gid=0)

--- a/docs/how_to_integrate.md
+++ b/docs/how_to_integrate.md
@@ -2,3 +2,21 @@
 
 *TBD*
 
+## Basic Integration
+
+-   Updating repositories.bzl
+    -   Layering you dependencies.
+-   Creating setup/*rules_mine*.bzl
+    -   Bringing in more dependencies
+    -   Registring toolchains
+-   Adding tests
+    -   Unit tests
+    -   Integration tests
+
+## Advanced Topics
+
+### Pinning a depedency
+
+If you must pin a dependency to a particular version, you may not call it by the
+canonical name. You *must* give it a private name (e.g.
+@rules_mine_bazel_skylib).

--- a/docs/how_to_integrate.md
+++ b/docs/how_to_integrate.md
@@ -162,3 +162,7 @@ At a minimum, you must add yourself to the
 -   If you are providing a language toolchain, then add that directly to the
     ["hello bazel"](https://github.com/bazelbuild/bazel-federation/tree/master/tests/integration/hello_bazel)
     example.
+
+The next step is to make sure there is test coverage on CI.
+
+TODO(fweikert): Add instructions for editing the .yaml files.

--- a/docs/how_to_integrate.md
+++ b/docs/how_to_integrate.md
@@ -1,22 +1,164 @@
 # Bazel Federation - How to integrate rules
 
-*TBD*
+This is a guide for rule authors. It describes the steps needed to have your
+rules play properly in the Bazel Federation. The general pattern is
 
-## Basic Integration
+1.  Consider the dependencies your user will need to *use* your rules vs. those
+    need to build, test and distribute your rules.
+1.  Verify that the versions of your dependencies do not conflict with the
+    federation.
+1.  Provide tagged releases for your rules rather than github commits
+1.  Add the configuration needed to make your rules part of the federation.
 
--   Updating repositories.bzl
-    -   Layering you dependencies.
--   Creating setup/*rules_mine*.bzl
-    -   Bringing in more dependencies
-    -   Registring toolchains
--   Adding tests
-    -   Unit tests
-    -   Integration tests
+## Bring your dependencies up to date
 
-## Advanced Topics
+**Critical point**: The Federation solves the diamond dependency problem in a
+blunt, but effective way - the Federation gets to pick a single version of each
+repo for canonically named rules.
 
-### Pinning a depedency
+What does that really mean?
 
-If you must pin a dependency to a particular version, you may not call it by the
-canonical name. You *must* give it a private name (e.g.
-@rules_mine_bazel_skylib).
+Every rule set has a canonical name. For example,
+[bazel-skylib](https://github.com/bazelbuild/bazel-skylib) is known as
+`bazel_skylib`. Its documentation talks about `bazel_skylib`. It might reference
+that name from within its own rules. Your transitive dependencies will probably
+reference it by that name.
+
+**When at all possible, use the canoncial name for a repo and take the version
+that the Federation provides.**
+
+If you really need to pin to a version, you may do that, but you will have to
+load that repo under a different name and refer to it that way (e.g.
+`@rules_mine_bazel_skylib`). If you can't make that work, then you'll have to
+work with the other rule owners to eventually come up with a common release you
+can all use.
+
+Note that this only applies to repos that your users will need to use your
+rules. Your own WORKSPACE file may include whatever it wants for the purposes of
+stress testing your rules and building your distribution. For example, we
+recommend using [stardoc](https://github.com/bazelbuild/stardoc) to generate
+your documentation and [rules_pkg](https://github.com/bazelbuild/rules_pkg) to
+create distribution archives, but you should structure your deps() functions so
+those are not needed by your users.
+
+The recommended task at this point is to update all of your dependency versions
+to the versions used in the Federation release you are trying to integrate into.
+If everything works, great. If not, you'll have to resolve that:
+
+-   maybe pin (and rename) that repo
+-   maybe change your code to be compatible with the Federation release.
+-   maybe untangle and remove dependencies that are not actually needed by your
+    users.
+
+## Start doing the work needed to make releases
+
+**Critical point**: The Federation strongly prefers release artifacts. It will
+never point to a github repo at HEAD.
+
+There are a few reasons for this: - releases tagge by version provide much more
+context to your users and the people maintaining the Federation. - No
+strip_prefix. - You can get download stats from github for release artifacts.
+You can not get that for commit based downloads. Tracking downloads by version
+will allow you to see that your users are migrating (or not) from older releases
+to new ones.
+
+For an example of minimal release packaging, you might follow what `rules_pkg`
+does. The tarball is simply a
+[target to be built](https://github.com/bazelbuild/rules_pkg/blob/master/pkg/distro/BUILD).
+and the release page
+[looks like this](https://github.com/bazelbuild/rules_pkg/releases)
+
+## Add your repo to the Federation
+
+This involes 3 steps
+
+1.  Updating repositories.bzl
+1.  Creating setup/*rules_mine*.bzl
+1.  Adding tests
+
+The end result is that someone who wants to use your rules will have a
+`WORKSPACE` file that looks like
+
+```
+workspace(name = "my_project")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_repository(name = "bazel_federation", urls = [...], ...)
+
+load("@bazel_federation//:repositories.bzl",
+     "bazel_skylib"
+)
+
+bazel_skylib()
+load("@bazel_federation//setup:bazel_skylib.bzl", "bazel_skylib_setup")
+bazel_skylib_setup()
+```
+
+The methods provide all follow a common naming pattern for ease of use.
+
+*NOTE: In the future, we will be trying to eliminate the need to call the
+`_setup()` methods.*
+
+### Updating repositories.bzl
+
+All of the top level components of the Federation are listed in
+[repositories.bzl](https://github.com/bazelbuild/bazel-federation/blob/master/repositories.bzl)
+
+We will use the stanza for `bazel_skylib` as an example.
+
+```
+def bazel_skylib_deps():
+    pass
+
+def bazel_skylib():
+    bazel_skylib_deps()
+    maybe(
+        http_archive,
+        name = "bazel_skylib",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/0.9.0/bazel_skylib-0.9.0.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/0.9.0/bazel_skylib-0.9.0.tar.gz",
+        ],
+        sha256 = "1dde365491125a3db70731e25658dfdd3bc5dbdfd11b840b3e987ecf043c7ca0",
+    )
+```
+
+Each rule set has a macro that is simply the canoncial name for the rules. It
+begins with a call to a `{rule}`_deps() method, which is also in this file. If
+you depend on other top level components of the Federation, you should call the
+existing deps methods from your deps() method.
+
+**Critical point**: These methods always conditionally load repos. If a user
+does not call your top level method, they will never bring in your repo. If a
+user add their own repository rule to bring in some deeply nested dependency
+before calling any Federation methods, we will use their preferred version.
+
+### Create the setup methods
+
+The setup method is a bit of glue that lets the user load your dependencies
+using a method name they can predict from pattern. Example:
+
+```
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+def bazel_skylib_setup():
+    bazel_skylib_workspace()
+```
+
+This calls back to bazel_skylib (or your rules) to load the previously defined
+external deps method. In this method you may
+
+-   Bring in more transitive deps. You should alway guard that with `maybe()`.
+-   Register any toolchains.
+
+### Adding tests
+
+At a minimum, you must add yourself to the
+[integration tests](https://github.com/bazelbuild/bazel-federation/tree/master/tests/integration).
+
+-   Add your repository setup to the `WORKSPACE` file file there
+-   Add an example which uses your rules
+-   If you are providing a language toolchain, then add that directly to the
+    ["hello bazel"](https://github.com/bazelbuild/bazel-federation/tree/master/tests/integration/hello_bazel)
+    example.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,8 @@
 # Bazel Federation
 
-*NOTE: This document is a work in progress.  It is very much incomplete*
+*NOTE: This documentation site is a work in progress. It is very much
+incomplete.*
 
--  [About](about.md)
--  [How to integrate rules into the Federation](how_to_integrate.md)
--  [Code](https://github.com/bazelbuild/bazel-federation)
+-   [About](about.md)
+-   [How to integrate rules into the Federation](how_to_integrate.md)
+-   [Code](https://github.com/bazelbuild/bazel-federation)


### PR DESCRIPTION
I think I like the look of this. One long README.md for both users and rule makers is not a great experience. This provides a real site.
https://bazelbuild.github.io/bazel-federation/about.html