### PR TITLE
Bump rules_rust version

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -237,9 +237,9 @@ def rules_rust():
     maybe(
         http_archive,
         name = "io_bazel_rules_rust",
-        strip_prefix = "rules_rust-05bd7d1d1bd34225a6614fc131267181aee2b61e",
-        url = "https://github.com/bazelbuild/rules_rust/archive/05bd7d1d1bd34225a6614fc131267181aee2b61e.tar.gz",
-        sha256 = "55968c5377d9d9f4a5c61780c8a041d478eaac26d984d19fd589afaf12b353dc",
+        strip_prefix = "rules_rust-55f77017a7f5b08e525ebeab6e11d8896a4499d2",
+        url = "https://github.com/bazelbuild/rules_rust/archive/55f77017a7f5b08e525ebeab6e11d8896a4499d2.tar.gz",
+        sha256 = "b6da34e057a31b8a85e343c732de4af92a762f804fc36b0baa6c001423a70ebc",
     )
 
 def rules_sass_deps():


### PR DESCRIPTION
We need to use a version of rules_rust that includes https://github.com/bazelbuild/rules_rust/pull/252 in order to fix a breakage in the federation tests (https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/1209#df505afb-20a4-4056-ad06-2fa973dbc6c9).