### PR TITLE
Add helper scripts for pre-release testing on CI

### DIFF
--- a/.bazelci/bazel_skylib.yml
+++ b/.bazelci/bazel_skylib.yml
@@ -14,6 +14,7 @@ tasks:
     build_flags:
     - --incompatible_remap_main_repo
     setup:
+    - python3.7 patch_repositories.py
     - python3.7 create_project_workspace.py --project=bazel_skylib --internal=0
     test_flags:
     - --test_env=PATH
@@ -22,6 +23,7 @@ tasks:
     build_flags:
     - --incompatible_remap_main_repo
     setup:
+    - python3.6 patch_repositories.py
     - python3.6 create_project_workspace.py --project=bazel_skylib --internal=0
     test_flags:
     - --test_env=PATH
@@ -30,6 +32,7 @@ tasks:
     build_flags:
     - --incompatible_remap_main_repo
     setup:
+    - python3.6 patch_repositories.py
     - python3.6 create_project_workspace.py --project=bazel_skylib --internal=0
     test_flags:
     - --test_env=PATH
@@ -38,6 +41,7 @@ tasks:
     build_flags:
     - --incompatible_remap_main_repo
     setup:
+    - python.exe patch_repositories.py
     - python.exe create_project_workspace.py --project=bazel_skylib --internal=0
     test_flags:
     - --test_env=LOCALAPPDATA

--- a/.bazelci/examples.yml
+++ b/.bazelci/examples.yml
@@ -3,24 +3,32 @@ tasks:
     name: rules_pkg
     working_directory: rules_pkg
     platform: macos
+    setup:
+    - python3.7 patch_repositories.py
     build_targets:
     - "..."
   rules_pkg_ubuntu1604:
     name: rules_pkg
     working_directory: rules_pkg
     platform: ubuntu1604
+    setup:
+    - python3.6 patch_repositories.py
     build_targets:
     - "..."
   rules_pkg_ubuntu1804:
     name: rules_pkg
     working_directory: rules_pkg
     platform: ubuntu1804
+    setup:
+    - python3.6 patch_repositories.py
     build_targets:
     - "..."
   rules_pkg_windows:
     name: rules_pkg
     working_directory: rules_pkg
     platform: windows
+    setup:
+    - python.exe patch_repositories.py
     build_targets:
     - "..."
 
@@ -28,23 +36,31 @@ tasks:
     name: Stardoc
     working_directory: stardoc
     platform: macos
+    setup:
+    - python3.7 patch_repositories.py
     build_targets:
     - "..."
   stardoc_ubuntu1604:
     name: Stardoc
     working_directory: stardoc
     platform: ubuntu1604
+    setup:
+    - python3.6 patch_repositories.py
     build_targets:
     - "..."
   stardoc_ubuntu1804:
     name: Stardoc
     working_directory: stardoc
     platform: ubuntu1804
+    setup:
+    - python3.6 patch_repositories.py
     build_targets:
     - "..."
   stardoc_windows:
     name: Stardoc
     working_directory: stardoc
     platform: windows
+    setup:
+    - python.exe patch_repositories.py
     build_targets:
     - "..."

--- a/.bazelci/prelease_pipeline.yml
+++ b/.bazelci/prelease_pipeline.yml
@@ -1,0 +1,47 @@
+---
+steps:
+  - block: "Test project distro"
+    fields:
+      - text: "External repo name"
+        key: "prerelease-repo-name"
+        required: true
+      - text: "GitHub org"
+        key: "prerelease-gh-org"
+        required: true
+        default: "bazelbuild"
+      - text: "GitHub repo"
+        key: "prerelease-gh-repo"
+        required: true
+      - text: "Commit"
+        key: "prerelease-commit"
+        required: true
+      - text: "Distro target"
+        key: "prerelease-distro-target"
+        required: true
+        default: "//distro:relnotes"
+  - command: |-
+      python3.6 build_project_distro.py
+      curl -sS "https://raw.githubusercontent.com/bazelbuild/continuous-integration/master/buildkite/bazelci.py?$(date +%s)" -o bazelci.py
+      python3.6 bazelci.py project_pipeline | buildkite-agent pipeline upload
+    label: ":pipeline:"
+    agents:
+      - "queue=default"
+    plugins:
+      - docker#v3.2.0:
+          always-pull: true
+          environment:
+            - "ANDROID_HOME"
+            - "ANDROID_NDK_HOME"
+            - "BUILDKITE_ARTIFACT_UPLOAD_DESTINATION"
+          image: "gcr.io/bazel-public/ubuntu1804:java11"
+          network: "host"
+          privileged: true
+          propagate-environment: true
+          propagate-uid-gid: true
+          volumes:
+            - "/etc/group:/etc/group:ro"
+            - "/etc/passwd:/etc/passwd:ro"
+            - "/opt:/opt:ro"
+            - "/var/lib/buildkite-agent:/var/lib/buildkite-agent"
+            - "/var/lib/gitmirrors:/var/lib/gitmirrors:ro"
+            - "/var/run/docker.sock:/var/run/docker.sock"

--- a/.bazelci/rules_cc.yml
+++ b/.bazelci/rules_cc.yml
@@ -3,6 +3,7 @@ platforms:
     build_targets:
     - '@rules_cc//...'
     setup:
+    - python3.7 patch_repositories.py
     - python3.7 create_project_workspace.py --project=rules_cc
     test_flags:
     - --test_timeout=300
@@ -12,6 +13,7 @@ platforms:
     build_targets:
     - '@rules_cc//...'
     setup:
+    - python3.6 patch_repositories.py
     - python3.6 create_project_workspace.py --project=rules_cc
     test_flags:
     - --test_timeout=300
@@ -21,6 +23,7 @@ platforms:
     build_targets:
     - '@rules_cc//...'
     setup:
+    - python3.6 patch_repositories.py
     - python3.6 create_project_workspace.py --project=rules_cc
     test_flags:
     - --test_timeout=300
@@ -32,6 +35,7 @@ platforms:
     build_targets:
     - '@rules_cc//...'
     setup:
+    - python3.6 patch_repositories.py
     - python3.6 create_project_workspace.py --project=rules_cc
     test_flags:
     - --test_timeout=300
@@ -42,6 +46,7 @@ platforms:
     build_targets:
     - '@rules_cc//...'
     setup:
+    - python.exe patch_repositories.py
     - python.exe create_project_workspace.py --project=rules_cc
     test_flags:
     - --test_timeout=300

--- a/.bazelci/rules_java.yml
+++ b/.bazelci/rules_java.yml
@@ -5,20 +5,24 @@ tasks:
   macos:
     build_targets: *build_targets
     setup:
+    - python3.7 patch_repositories.py
     - python3.7 create_project_workspace.py --project=rules_java
   ubuntu1604:
     build_targets: *build_targets
     setup:
+    - python3.6 patch_repositories.py
     - python3.6 create_project_workspace.py --project=rules_java
   ubuntu1804:
     build_targets: *build_targets
     setup:
+    - python3.6 patch_repositories.py
     - python3.6 create_project_workspace.py --project=rules_java
   ubuntu1804_nojava:
     build_flags:
     - --javabase=@openjdk11_linux_archive//:runtime
     build_targets: *build_targets
     setup:
+    - python3.6 patch_repositories.py
     - python3.6 create_project_workspace.py --project=rules_java
   windows:
     build_targets: *build_targets

--- a/.bazelci/rules_python.yml
+++ b/.bazelci/rules_python.yml
@@ -8,13 +8,16 @@ targets: &targets
 platforms:
   macos:
     setup:
+    - python3.7 patch_repositories.py
     - python3.7 create_project_workspace.py --project=rules_python --internal=0
     <<: *targets
   ubuntu1604:
     setup:
+    - python3.6 patch_repositories.py
     - python3.6 create_project_workspace.py --project=rules_python --internal=0
     <<: *targets
   ubuntu1804:
     setup:
+    - python3.6 patch_repositories.py
     - python3.6 create_project_workspace.py --project=rules_python --internal=0
     <<: *targets

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -3,6 +3,8 @@ tasks:
     name: hello
     working_directory: integration/hello_bazel
     platform: macos
+    setup:
+    - python3.7 patch_repositories.py
     build_targets:
     - ":tarball"
     run_targets:
@@ -14,6 +16,8 @@ tasks:
     name: hello
     working_directory: integration/hello_bazel
     platform: ubuntu1604
+    setup:
+    - python3.6 patch_repositories.py
     build_targets:
     - ":tarball"
     run_targets:
@@ -25,6 +29,8 @@ tasks:
     name: hello
     working_directory: integration/hello_bazel
     platform: ubuntu1804
+    setup:
+    - python3.6 patch_repositories.py
     build_targets:
     - ":tarball"
     run_targets:
@@ -36,6 +42,8 @@ tasks:
     name: hello
     working_directory: integration/hello_bazel
     platform: windows
+    setup:
+    - python.exe patch_repositories.py
     build_targets:
     - ":hello_in_c"
     - ":HelloInJava"

--- a/build_project_distro.py
+++ b/build_project_distro.py
@@ -1,0 +1,114 @@
+import os
+import sys
+import tempfile
+import traceback
+import utils
+
+
+REPO_PATCHING_REQUIRED_META_DATA_KEY = "repo_patching_required"
+REPO_META_DATA_KEY = "prerelease-repo-name"
+ARCHIVE_META_DATA_KEY = "distro_path"
+
+
+def download_repository(org, repo, commit):
+    archive = fetch_source(org, repo, commit)
+    dest = extract_archive(archive)
+    return os.path.join(dest, "{}-{}".format(repo, commit))
+
+
+def fetch_source(org, repo, commit):
+    url = "https://github.com/{}/{}/archive/{}.zip".format(org, repo, commit)
+    utils.print_group("Fetching source from {}".format(url))
+    dest_path = os.path.join(tempfile.mkdtemp(), "{}.zip".format(repo))
+    process = utils.execute_command("curl", "-sSL", url, "-o", dest_path)
+
+    if process.returncode:
+        raise Exception("Unable to download from {}: {}".format(url, process.stderr))
+
+    return dest_path
+
+
+def extract_archive(archive_path):
+    utils.print_group("Extracting {}".format(archive_path))
+    dest = tempfile.mkdtemp()
+    process = utils.execute_command("unzip", archive_path, "-d", dest)
+
+    if process.returncode:
+        raise Exception("Failed to extract {} to {}: {}".format(archive_path, dest, process.stderr))
+
+    return dest
+
+
+def build_distro(repo_dir, target):
+    utils.print_group("Building distro {} in {}".format(target, repo_dir))
+    os.chdir(repo_dir)
+
+    process = utils.execute_command("bazel", "build", target)
+    if process.returncode:
+        raise Exception("Failed to build {}: {}".format(target, process.stderr))
+
+    print(process.stdout)
+
+    process = utils.execute_command(
+        "find", "-L", os.path.join(repo_dir, "bazel-bin"), "-name", "*.tar.gz"
+    )
+    if process.returncode:
+        raise Exception("Unable to find tar.gz output file: {}".format(process.stderr))
+
+    lines = process.stdout.split("\n")
+    files = [l for l in lines if l.strip()]
+    if len(files) != 1:
+        raise Exception(
+            "Expected exactly one tar.gz file, not {}: {}".format(len(files), ", ".join(files))
+        )
+
+    return files[0]
+
+
+def save_distro(distro_path):
+    utils.print_group("Uploading distro from {}".format(distro_path))
+    # Don't upload from distro_path directly since Buildkite will keep the long path
+    # as part of the artifact name.
+    dirname, basename = os.path.split(distro_path)
+    os.chdir(dirname)
+    utils.upload_file(basename)
+    utils.set_meta_data(ARCHIVE_META_DATA_KEY, basename)
+
+
+def request_repo_patching():
+    utils.print_group("Requesting repositories patching in subsequent steps {}")
+    utils.set_meta_data(REPO_PATCHING_REQUIRED_META_DATA_KEY, "True")
+
+
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
+
+    utils.PRINT_COMMANDS = True
+
+    try:
+        repo = utils.get_meta_data(REPO_META_DATA_KEY)
+        gh_org = utils.get_meta_data("prerelease-gh-org")
+        gh_repo = utils.get_meta_data("prerelease-gh-repo")
+        commit = utils.get_meta_data("prerelease-commit")
+        target = utils.get_meta_data("prerelease-distro-target")
+
+        text = f"Testing {repo} distro (<a href='https://github.com/{gh_org}/{gh_repo}/commit/{commit}'>{gh_org}/{gh_repo} @ {commit}</a>)"
+        utils.execute_command(
+            "buildkite-agent", "annotate", "--style", "info", "--context", "distro", text
+        )
+
+        repo_dir = download_repository(gh_org, gh_repo, commit)
+        distro_path = build_distro(repo_dir, target)
+        save_distro(distro_path)
+        request_repo_patching()
+    except Exception as ex:
+        utils.eprint("".join(traceback.format_exception(None, ex, ex.__traceback__)))
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/import_presubmit_config.py
+++ b/import_presubmit_config.py
@@ -106,9 +106,11 @@ def load_remote_config(http_url):
 def transform_config(project_name, repository_name, config):
     tasks = config.get("tasks") or config.get("platforms")
     for name, task_config in tasks.items():
+        python = get_python_version_for_task(name, task_config)
         task_config["setup"] = [
+            "%s patch_repositories.py" % python,
             "%s create_project_workspace.py --project=%s --repo=%s"
-            % (get_python_version_for_task(name, task_config), project_name, repository_name)
+            % (python, project_name, repository_name)
         ]
         for field in ("run_targets", "build_targets", "test_targets"):
             targets = task_config.get(field)

--- a/patch_repositories.py
+++ b/patch_repositories.py
@@ -1,0 +1,181 @@
+import argparse
+import build_project_distro
+import os
+import re
+import sys
+import tempfile
+import utils
+
+
+def download_distro(project_name):
+    src_path = utils.get_meta_data(build_project_distro.ARCHIVE_META_DATA_KEY)
+    dest_dir = tempfile.mkdtemp()
+
+    # Buildkite wants a trailing slash
+    if not dest_dir.endswith("/"):
+        dest_dir += "/"
+
+    utils.print_group("Downloading {} distro from Buildkite".format(project_name))
+    process = utils.execute_command("buildkite-agent", "artifact", "download", src_path, dest_dir)
+    if process.returncode:
+        raise Exception("Failed to download distro from {}: {}".format(src_path, process.stderr))
+
+    return os.path.join(dest_dir, src_path)
+
+
+def extract_distro(project_name, archive_path):
+    utils.print_group("Extracting {} distro from {}".format(project_name, archive_path))
+    dest_dir = tempfile.mkdtemp()
+    process = utils.execute_command("tar", "-xf", archive_path, "-C", dest_dir)
+    if process.returncode:
+        raise Exception(
+            "Failed to extract {} distro to {}: {}".format(project_name, dest_dir, process.stderr)
+        )
+
+    # Unlike other repository rules, local_repository requires the presence of a WORKSPACE file
+    # (even though its content is being ignored).
+    # However, most distributions don't contain a WORKSPACE file, hence we create one in that case.
+    process = utils.execute_command("touch", os.path.join(dest_dir, "WORKSPACE"))
+    if process.returncode:
+        raise Exception("Failed to ensure that a WORKSPACE file exists: {}".format(process.stderr))
+
+    return dest_dir
+
+
+def rewrite_repositories_file(repositories_file, project_name, project_root):
+    utils.print_group(
+        "Rewriting {} to point {} at {}".format(repositories_file, project_name, project_root)
+    )
+    transformations = [
+        lambda content: fix_function(repositories_file, content, project_name, project_root)
+    ]
+    rewrite_file(repositories_file, transformations)
+
+
+def rewrite_file(path, transformations):
+    with open(path, "r") as file:
+        content = file.read()
+
+    for t in transformations:
+        content = t(content)
+
+    with open(path, "w") as file:
+        file.write(content)
+
+
+def fix_function(repositories_file, content, project_name, project_root):
+    lines = content.split("\n")
+
+    function_index = find_function_index(repositories_file, project_name, lines)
+    next_element_index = find_next_element_index(lines, function_index)
+
+    old_function_lines = lines[function_index:next_element_index]
+    function_lines = create_function_lines(old_function_lines, project_name, project_root)
+    lines = lines[:function_index] + function_lines + lines[next_element_index:]
+    return "\n".join(lines)
+
+
+def find_function_index(path, function_name, lines):
+    prefix = "def {}(".format(function_name)
+    for i, l in enumerate(lines):
+        if l.startswith(prefix):
+            return i
+
+    raise Exception("There is no function {}() in {}".format(function_name, path))
+
+
+def find_next_element_index(lines, function_index):
+    index = function_index + 1
+    while index < len(lines):
+        l = lines[index]
+        if not l or l[0] not in (" ", "\t"):
+            break
+
+        index += 1
+
+    # First line that no longer belongs to the function
+    return index
+
+
+def create_function_lines(old_lines, project_name, project_root):
+    result = ["def {}():".format(project_name)]
+
+    # Very simple and error-prone algorithm.
+    # TODO: improve if necessary
+    indent = get_indent(old_lines)
+    deps_func = "{}_deps()".format(project_name)
+    if has_function_call(old_lines, deps_func):
+        result.append("{}{}".format(indent, deps_func))
+
+    # Windows: We need to escape backslashes
+    project_root = project_root.replace("\\", "\\\\")
+    result += [
+        f"{indent}native.local_repository(",
+        f'{indent}{indent}name = "{project_name}",',
+        f'{indent}{indent}path = "{project_root}",',
+        f"{indent})",
+    ]
+    return result
+
+
+def get_indent(function_lines):
+    # Very simple and error-prone algorithm.
+    # TODO: improve if necessary
+    first_body_line = function_lines[1]
+    match = re.search(r"\s+", first_body_line)
+    if not match:
+        raise Exception("Something went wrong :(")
+
+    return match.group(0)
+
+
+def has_function_call(function_lines, function_name):
+    for l in function_lines:
+        if l.lstrip().startswith(function_name):
+            return True
+
+    return False
+
+
+def upload_repositories_file(repositories_file):
+    utils.print_group("Uploading {} file".format(repositories_file))
+    utils.upload_file(repositories_file)
+
+
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
+
+    utils.PRINT_COMMANDS = True
+
+    parser = argparse.ArgumentParser(description="Bazel Federation CI Patch Repositories Script")
+    parser.add_argument(
+        "--repositories_file",
+        type=str,
+        default="repositories.bzl",
+        help="Path of the file that contains the repository functions.",
+    )
+
+    args = parser.parse_args(argv)
+
+    utils.print_group("Executing patch_repositories.py...")
+
+    patching_required = utils.get_meta_data(
+        build_project_distro.REPO_PATCHING_REQUIRED_META_DATA_KEY, ""
+    )
+    if not patching_required:
+        utils.eprint("Running as part of a regular presubmit -> no repositories patching required")
+        return 0
+
+    project_name = utils.get_meta_data(build_project_distro.REPO_META_DATA_KEY)
+    archive_path = download_distro(project_name)
+    project_root = extract_distro(project_name, archive_path)
+    rewrite_repositories_file(args.repositories_file, project_name, project_root)
+    upload_repositories_file(args.repositories_file)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/utils.py
+++ b/utils.py
@@ -14,9 +14,60 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import subprocess
 import sys
+
+
+PRINT_COMMANDS = True
+_SENTINEL = "meta_data_sentinel_value"
 
 
 def eprint(msg):
     """Print to stderr and flush (just in case)."""
     print(msg, flush=True, file=sys.stderr)
+
+
+def print_group(name, collapsed=True):
+    sign = "-" if collapsed else "+"
+    eprint("\n\n{} {}\n\n".format(sign * 3, name))
+
+
+def execute_command(*args):
+    if PRINT_COMMANDS:
+        eprint(" ".join(args))
+
+    process = subprocess.run(
+        args, check=False, stdout=subprocess.PIPE, errors="replace", universal_newlines=True
+    )
+
+    return process
+
+
+def get_meta_data(key, default=_SENTINEL):
+    process = execute_command(
+        "buildkite-agent", "meta-data", "get", key, "--default", default
+    )
+    if process.returncode:
+        raise ValueError("Failed to read meta data '{}': {}".format(key, process.stderr))
+
+    value = process.stdout
+    if value == _SENTINEL:
+        raise ValueError("Missing meta data value for key '{}'".format(key))
+
+    return value
+
+
+def set_meta_data(key, value):
+    process = execute_command(
+        "buildkite-agent", "meta-data", "set", key, value
+    )
+    if process.returncode:
+        raise ValueError("Failed to write meta data '{}': {}".format(key, process.stderr))
+
+    return process.stdout
+
+
+def upload_file(path):
+    process = execute_command("buildkite-agent", "artifact", "upload", path)
+    if process.returncode:
+        raise Exception("Failed to upload {}: {}".format(path, process.stderr))


### PR DESCRIPTION
This commit allows us to create a presubmit pipeline that answers the question "If I would cut a rules_foo release at a certain commit, would this release pass the federation presubmit pipeline?".
As a result we can detect broken releases of member projects (e.g. due to missing files) before actually cutting them.

This feature relies on a custom pipeline configuration and two Python scripts:

- The pipeline configuration in .bazelci/prelease_pipeline.yml asks the user to specify which repository should be tested at which commit.
- build_project_distro.py is executed once per build as part of the "print pipeline" step. It processes the user input to fetch the correct repository at the right commit, then builds the release distribution and stores it as Buildkite artifact.
- patch_repositories.py runs as setup step at the beginning of every CI job. It downloads the distribution artifact from Buildkite, extracts it and rewrites repositories.bzl to add a local_repository that points at the extracted files.

Consequently, this commit also modified all existing presubmit configuration files to run patch_repositories.py as part of the setup steps.
However, patch_repositories.py only runs any commands when pre-release testing has been requested. It won't do anything if the pipeline runs a "regular" presubmit.

Example: https://buildkite.com/bazel/bazel-federation-distro-pre-release-testing/builds/26

Progress towards #77