### PR TITLE
rules_python: Move non-distro targets to a separate presubmit config

### DIFF
--- a/.bazelci/rules_python.yml
+++ b/.bazelci/rules_python.yml
@@ -1,26 +1,20 @@
+---
+# TOOD(https://github.com/bazelbuild/bazel-federation/issues/78): remove internal flag once it defaults to False
 targets: &targets
   build_targets:
   - "--"
-  - "@rules_python//examples/..."
-  - "@rules_python//experimental/..."
   - "@rules_python//python/..."
-  - "@rules_python//packaging/..."
   - "@rules_python//tools/..."
-  test_targets:
-  - "--"
-  - "@rules_python//..."
-  # TODO(https://github.com/bazelbuild/rules_python/issues/225): enable test once fixed
-  - "-@rules_python//experimental/examples/wheel/..."
 platforms:
   macos:
     setup:
-    - python3.7 create_project_workspace.py --project=rules_python
+    - python3.7 create_project_workspace.py --project=rules_python --internal=0
     <<: *targets
   ubuntu1604:
     setup:
-    - python3.6 create_project_workspace.py --project=rules_python
+    - python3.6 create_project_workspace.py --project=rules_python --internal=0
     <<: *targets
   ubuntu1804:
     setup:
-    - python3.6 create_project_workspace.py --project=rules_python
+    - python3.6 create_project_workspace.py --project=rules_python --internal=0
     <<: *targets

--- a/.bazelci/rules_python_internal.yml
+++ b/.bazelci/rules_python_internal.yml
@@ -1,0 +1,24 @@
+targets: &targets
+  build_targets:
+  - "--"
+  - "@rules_python//examples/..."
+  - "@rules_python//experimental/..."
+  - "@rules_python//packaging/..."
+  test_targets:
+  - "--"
+  - "@rules_python//..."
+  # TODO(https://github.com/bazelbuild/rules_python/issues/225): enable test once fixed
+  - "-@rules_python//experimental/examples/wheel/..."
+platforms:
+  macos:
+    setup:
+    - python3.7 create_project_workspace.py --project=rules_python --internal=1
+    <<: *targets
+  ubuntu1604:
+    setup:
+    - python3.6 create_project_workspace.py --project=rules_python --internal=1
+    <<: *targets
+  ubuntu1804:
+    setup:
+    - python3.6 create_project_workspace.py --project=rules_python --internal=1
+    <<: *targets


### PR DESCRIPTION
As of #75 the federation references a rules_python release instead of the entire repository. However, the presubmit failed (as expected) since some test targets cover files that are not part of the distribution.
The present commit moves these tests to a separate file so that they can be tested again once #78 is solved. As a result, #75 is unblocked and can be merged.

Tested: https://buildkite.com/bazel/fwes-federation-pipeline/builds/10