### PR TITLE
force using bazel 1.1 on the 1.x branch

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,3 +1,4 @@
+bazel: 1.1.0
 imports:
 - bazel_skylib.yml
 - examples.yml


### PR DESCRIPTION
We'll have to update to 1.2 when 1.2 comes out.

So now the important CIs are

federation/1.x, 2.x,, .... going forward
federation Bazel@Head + migration incompatible changes
   - tells us what rule sets need to update for next major bazel release
federation + bazel@head 
   - tells us that we have just introduced a breaking change that is not hidden behind a flag.



