### PR TITLE
Remove flag --incompatible_remap_main_repo

### DIFF
--- a/.bazelci/bazel_skylib.yml
+++ b/.bazelci/bazel_skylib.yml
@@ -21,8 +21,6 @@ common: &common
 buildifier: latest
 tasks:
   macos:
-    build_flags:
-    - --incompatible_remap_main_repo
     setup:
     - python3.7 scripts/patch_repositories.py
     - python3.7 scripts/create_project_workspace.py --project=bazel_skylib
@@ -30,8 +28,6 @@ tasks:
     - --test_env=PATH
     <<: *common
   ubuntu1604:
-    build_flags:
-    - --incompatible_remap_main_repo
     setup:
     - python3.6 scripts/patch_repositories.py
     - python3.6 scripts/create_project_workspace.py --project=bazel_skylib
@@ -39,8 +35,6 @@ tasks:
     - --test_env=PATH
     <<: *common
   ubuntu1804:
-    build_flags:
-    - --incompatible_remap_main_repo
     setup:
     - python3.6 scripts/patch_repositories.py
     - python3.6 scripts/create_project_workspace.py --project=bazel_skylib
@@ -48,8 +42,6 @@ tasks:
     - --test_env=PATH
     <<: *common
   windows:
-    build_flags:
-    - --incompatible_remap_main_repo
     setup:
     - python.exe scripts/patch_repositories.py
     - python.exe scripts/create_project_workspace.py --project=bazel_skylib


### PR DESCRIPTION
It's on by default since Bazel 2.0, and the flag is now going away.

https://github.com/bazelbuild/bazel/issues/7130