### PR TITLE
Create bzl_library targets

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,3 +1,5 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 filegroup(
     name = "standard_package",
     srcs = glob([
@@ -7,4 +9,49 @@ filegroup(
         "third_party/**",
     ]),
     visibility = ["@//distro:__pkg__"],
+)
+
+bzl_library(
+    name = "java_repositories",
+    srcs = ["java_repositories.bzl"],
+    visibility = ["//visibility:public"],
+    # Temporarily omit @bazel_tools//... bzl files from the bzl_library until
+    # they are `exports_files`'d in a released version of Bazel.
+    deps = [
+        #"@bazel_tools//tools/build_defs/repo:http.bzl",
+        #"@bazel_tools//tools/build_defs/repo:utils.bzl",
+    ],  # keep
+)
+
+bzl_library(
+    name = "repositories",
+    srcs = ["repositories.bzl"],
+    visibility = ["//visibility:public"],
+    # Temporarily omit @bazel_tools//... bzl files from the bzl_library until
+    # they are `exports_files`'d in a released version of Bazel.
+    deps = [
+        ":third_party_repositories",
+        #"@bazel_tools//tools/build_defs/repo:git.bzl",
+        #"@bazel_tools//tools/build_defs/repo:http.bzl",
+        #"@bazel_tools//tools/build_defs/repo:utils.bzl",
+    ],  # keep
+)
+
+bzl_library(
+    name = "third_party_repositories",
+    srcs = ["third_party_repositories.bzl"],
+    visibility = ["//visibility:public"],
+    # Temporarily omit @bazel_tools//... bzl files from the bzl_library until
+    # they are `exports_files`'d in a released version of Bazel.
+    deps = [
+        #"@bazel_tools//tools/build_defs/repo:git.bzl",
+        #"@bazel_tools//tools/build_defs/repo:http.bzl",
+        #"@bazel_tools//tools/build_defs/repo:utils.bzl",
+    ],  # keep
+)
+
+bzl_library(
+    name = "version",
+    srcs = ["version.bzl"],
+    visibility = ["//visibility:public"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,17 @@
 workspace(name = "bazel_federation")
 
 load("@bazel_federation//:repositories.bzl", "rules_pkg")
+
 rules_pkg()
+
 load("@bazel_federation//setup:rules_pkg.bzl", "rules_pkg_setup")
+
 rules_pkg_setup()
+
+load("@bazel_federation//:repositories.bzl", "bazel_skylib")
+
+bazel_skylib()
+
+load("@bazel_federation//setup:bazel_skylib.bzl", "bazel_skylib_setup")
+
+bazel_skylib_setup()

--- a/examples/stardoc/BUILD
+++ b/examples/stardoc/BUILD
@@ -6,9 +6,7 @@ package(default_visibility = ["//visibility:private"])
 
 bzl_library(
     name = "my_rule",
-    srcs = [
-        "my_rule.bzl",
-    ],
+    srcs = ["my_rule.bzl"],
     visibility = ["//visibility:public"],
 )
 
@@ -22,12 +20,11 @@ stardoc(
     deps = [":my_rule"],
 )
 
-
 my_rule(
     name = "example",
+    out = "example.txt",
     deps = [
         ":BUILD",
         ":my_rule.bzl",
     ],
-    out = "example.txt",
 )

--- a/internal/deps/BUILD
+++ b/internal/deps/BUILD
@@ -1,0 +1,29 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "bazel_skylib",
+    srcs = ["bazel_skylib.bzl"],
+    visibility = ["//:__subpackages__"],
+    deps = ["@bazel_skylib//:internal_deps"],
+)
+
+bzl_library(
+    name = "rules_cc",
+    srcs = ["rules_cc.bzl"],
+    visibility = ["//:__subpackages__"],
+    deps = ["@rules_cc//:internal_deps"],
+)
+
+bzl_library(
+    name = "rules_java",
+    srcs = ["rules_java.bzl"],
+    visibility = ["//:__subpackages__"],
+    deps = ["@rules_java//:internal_deps"],
+)
+
+bzl_library(
+    name = "rules_python",
+    srcs = ["rules_python.bzl"],
+    visibility = ["//:__subpackages__"],
+    deps = ["@rules_python//:internal_deps"],
+)

--- a/internal/setup/BUILD
+++ b/internal/setup/BUILD
@@ -1,0 +1,29 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "bazel_skylib",
+    srcs = ["bazel_skylib.bzl"],
+    visibility = ["//:__subpackages__"],
+    deps = ["@bazel_skylib//:internal_setup"],
+)
+
+bzl_library(
+    name = "rules_cc",
+    srcs = ["rules_cc.bzl"],
+    visibility = ["//:__subpackages__"],
+    deps = ["@rules_cc//:internal_setup"],
+)
+
+bzl_library(
+    name = "rules_java",
+    srcs = ["rules_java.bzl"],
+    visibility = ["//:__subpackages__"],
+    deps = ["@rules_java//:internal_setup"],
+)
+
+bzl_library(
+    name = "rules_python",
+    srcs = ["rules_python.bzl"],
+    visibility = ["//:__subpackages__"],
+    deps = ["@rules_python//:internal_setup"],
+)

--- a/setup/BUILD
+++ b/setup/BUILD
@@ -1,7 +1,72 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 exports_files(glob(["*.bzl"]))
 
 filegroup(
     name = "standard_package",
-    srcs = glob(["BUILD", "*.bzl"]),
+    srcs = glob([
+        "BUILD",
+        "*.bzl",
+    ]),
     visibility = ["@//distro:__pkg__"],
+)
+
+bzl_library(
+    name = "bazel_skylib",
+    srcs = ["bazel_skylib.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@bazel_skylib//:workspace"],
+)
+
+bzl_library(
+    name = "bazel_stardoc",
+    srcs = ["bazel_stardoc.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@bazel_federation//setup:rules_java"],
+)
+
+bzl_library(
+    name = "rules_go",
+    srcs = ["rules_go.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@bazel_federation//setup:bazel_skylib",
+        "@io_bazel_rules_go//go:deps",
+    ],
+)
+
+bzl_library(
+    name = "rules_java",
+    srcs = ["rules_java.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@rules_java//java:repositories"],
+)
+
+bzl_library(
+    name = "rules_python",
+    srcs = ["rules_python.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@rules_python//python:pip"],
+)
+
+bzl_library(
+    name = "rules_rust",
+    srcs = ["rules_rust.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@io_bazel_rules_rust//:workspace",
+        "@io_bazel_rules_rust//rust:repositories",
+    ],
+)
+
+bzl_library(
+    name = "rules_cc",
+    srcs = ["rules_cc.bzl"],
+    visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "rules_pkg",
+    srcs = ["rules_pkg.bzl"],
+    visibility = ["//visibility:public"],
 )

--- a/tests/integration/BUILD
+++ b/tests/integration/BUILD
@@ -1,10 +1,9 @@
-package(default_visibility=["//visibility:public"])
-
+package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "srcs",
     srcs = [
         "BUILD",
         "WORKSPACE",
-    ]
+    ],
 )

--- a/tests/integration/hello_bazel/BUILD
+++ b/tests/integration/hello_bazel/BUILD
@@ -6,16 +6,7 @@ load("@rules_cc//cc:defs.bzl", "cc_library", "cc_binary")
 load("@rules_java//java:defs.bzl", "java_library", "java_binary")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
-
 load(":my_rule.bzl", "my_rule")
-
-bzl_library(
-    name = "my_rule",
-    srcs = [
-        "my_rule.bzl",
-    ],
-    visibility = ["//visibility:public"],
-)
 
 stardoc(
     name = "my_rule_doc",
@@ -27,7 +18,6 @@ stardoc(
     deps = [":my_rule"],
 )
 
-
 my_rule(
     name = "example",
     deps = [
@@ -36,7 +26,6 @@ my_rule(
     ],
     out = "example.txt",
 )
-
 
 # A C++ program
 
@@ -51,7 +40,6 @@ cc_library(
     srcs = ["hello_lib.cc"],
     hdrs = ["hello_lib.h"],
 )
-
 
 go_library(
     name = "lib",
@@ -106,7 +94,6 @@ rust_test(
     deps = [":rust_lib"],
 )
 
-
 pkg_tar(
     name = "tarball",
     srcs = glob(["**"]) + [
@@ -119,4 +106,10 @@ pkg_tar(
     ],
     strip_prefix = "/",
     package_dir = "federation/sample",
+)
+
+bzl_library(
+    name = "my_rule",
+    srcs = ["my_rule.bzl"],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This is to allow people who transitively depend on this repo to use
stardoc to generate documentation for their Bazel targets.

For the origin of this commit, please see
https://github.com/bazelbuild/bazel-gazelle/pull/760#issuecomment-712961346
and the linked PRs in that thread.